### PR TITLE
[ECO-5377] Tighten up threading requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,7 @@ This is an Ably-internal library that defines the private APIs that the [Ably Pu
 > This library is an implementation detail of the Ably SDK and should not be used directly by end users of the SDK.
 
 Further documentation will be added in the future.
+
+## Conventions
+
+- Methods whose names begin with `nosync_` must always be called on the client's internal queue.

--- a/Sources/_AblyPluginSupportPrivate/include/APLiveObjectsPlugin.h
+++ b/Sources/_AblyPluginSupportPrivate/include/APLiveObjectsPlugin.h
@@ -32,7 +32,7 @@ NS_SWIFT_SENDABLE
 /// ably-cocoa will call this method when initializing an `ARTRealtimeChannel` instance.
 ///
 /// The plugin can use this as an opportunity to perform any initial setup of LiveObjects functionality for this channel.
-- (void)prepareChannel:(id<APRealtimeChannel>)channel client:(id<APRealtimeClient>)client;
+- (void)nosync_prepareChannel:(id<APRealtimeChannel>)channel client:(id<APRealtimeClient>)client;
 
 /// Decodes an `ObjectMessage` received over the wire.
 ///
@@ -59,34 +59,29 @@ NS_SWIFT_SENDABLE
 
 /// Called when a channel received an `ATTACHED` `ProtocolMessage`. (This is copied from ably-js, will document this method properly once exact meaning decided.)
 ///
-/// TODO: what thread is this called on, and does it matter? Decide in https://github.com/ably/ably-cocoa-liveobjects-plugin/issues/3
-///
 /// Parameters:
 /// - channel: The channel that received the `ProtocolMessage`.
 /// - hasObjects: Whether the `ProtocolMessage` has the `HAS_OBJECTS` flag set.
-- (void)onChannelAttached:(id<APRealtimeChannel>)channel
-               hasObjects:(BOOL)hasObjects;
+- (void)nosync_onChannelAttached:(id<APRealtimeChannel>)channel
+                      hasObjects:(BOOL)hasObjects
+  NS_SWIFT_NAME(nosync_onChannelAttached(_:hasObjects:));
 
 /// Processes a received `OBJECT` `ProtocolMessage`.
 ///
-/// TODO: what thread is this called on, and does it matter? Decide in https://github.com/ably/ably-cocoa-liveobjects-plugin/issues/3
-///
 /// Parameters:
 /// - objectMessages: The contents of the `ProtocolMessage`'s `state` property.
 /// - channel: The channel on which the `ProtocolMessage` was received.
-- (void)handleObjectProtocolMessageWithObjectMessages:(NSArray<id<APObjectMessageProtocol>> *)objectMessages
-                                              channel:(id<APRealtimeChannel>)channel;
+- (void)nosync_handleObjectProtocolMessageWithObjectMessages:(NSArray<id<APObjectMessageProtocol>> *)objectMessages
+                                                     channel:(id<APRealtimeChannel>)channel;
 
 /// Processes a received `OBJECT_SYNC` `ProtocolMessage`.
 ///
-/// TODO: what thread is this called on, and does it matter? Decide in https://github.com/ably/ably-cocoa-liveobjects-plugin/issues/3
-///
 /// Parameters:
 /// - objectMessages: The contents of the `ProtocolMessage`'s `state` property.
 /// - channel: The channel on which the `ProtocolMessage` was received.
-- (void)handleObjectSyncProtocolMessageWithObjectMessages:(NSArray<id<APObjectMessageProtocol>> *)objectMessages
-                             protocolMessageChannelSerial:(nullable NSString *)protocolMessageChannelSerial
-                                                  channel:(id<APRealtimeChannel>)channel;
+- (void)nosync_handleObjectSyncProtocolMessageWithObjectMessages:(NSArray<id<APObjectMessageProtocol>> *)objectMessages
+                                    protocolMessageChannelSerial:(nullable NSString *)protocolMessageChannelSerial
+                                                         channel:(id<APRealtimeChannel>)channel;
 
 @end
 

--- a/Sources/_AblyPluginSupportPrivate/include/APPluginAPI.h
+++ b/Sources/_AblyPluginSupportPrivate/include/APPluginAPI.h
@@ -25,13 +25,13 @@ NS_SWIFT_SENDABLE
 /// Allows a plugin to store arbitrary key-value data on a channel.
 ///
 /// The channel stores a strong reference to `value`.
-- (void)setPluginDataValue:(id)value
-                    forKey:(NSString *)key
-                   channel:(id<APRealtimeChannel>)channel;
+- (void)nosync_setPluginDataValue:(id)value
+                           forKey:(NSString *)key
+                          channel:(id<APRealtimeChannel>)channel;
 
 /// Allows a plugin to retrieve arbitrary key-value data that was previously stored on a channel using `-setPluginDataValue:forKey:channel:`.
-- (nullable id)pluginDataValueForKey:(NSString *)key
-                             channel:(id<APRealtimeChannel>)channel;
+- (nullable id)nosync_pluginDataValueForKey:(NSString *)key
+                                    channel:(id<APRealtimeChannel>)channel;
 
 /// Allows a plugin to store arbitrary key-value data in an `ARTClientOptions`. This allows a plugin to define its own client options.
 ///
@@ -59,18 +59,18 @@ NS_SWIFT_SENDABLE
 
 /// Provides plugins with the queue which a given client uses to synchronize its internal state.
 ///
-/// Certain `APPluginAPIProtocol` methods must be called on this queue (the method will document when this is the case).
+/// All `_AblyPluginSupportPrivate` methods whose names begin with `nosync_` must be called on this queue.
 - (dispatch_queue_t)internalQueueForClient:(id<APRealtimeClient>)client;
 
 /// Sends an `OBJECT` `ProtocolMessage` on a channel and indicates the result of waiting for an `ACK`. TODO there is still some deciding to be done about the exact contract of this method.
 ///
-/// This method must be called on the client's internal queue (see `-internalQueueForClient:`).
-- (void)sendObjectWithObjectMessages:(NSArray<id<APObjectMessageProtocol>> *)objectMessages
-                             channel:(id<APRealtimeChannel>)channel
-                          completion:(void (^ _Nullable)(_Nullable id<APPublicErrorInfo> error))completion;
+/// The completion handler will be called on the client's internal queue (see `-internalQueueForClient:`).
+- (void)nosync_sendObjectWithObjectMessages:(NSArray<id<APObjectMessageProtocol>> *)objectMessages
+                                    channel:(id<APRealtimeChannel>)channel
+                                 completion:(void (^ _Nullable)(_Nullable id<APPublicErrorInfo> error))completion;
 
 /// Returns a realtime channel's current state.
-- (APRealtimeChannelState)stateForChannel:(id<APRealtimeChannel>)channel;
+- (APRealtimeChannelState)nosync_stateForChannel:(id<APRealtimeChannel>)channel;
 
 /// Logs a message to a logger.
 - (void)log:(NSString *)message


### PR DESCRIPTION
Restrict more things to the ably-cocoa internal queue, and adopt the same naming convention as ably-cocoa to indicate this.

Relates to https://github.com/ably/ably-liveobjects-swift-plugin/pull/85, in which I isolate all of the LiveObject plugin's internal state to the ably-cocoa internal queue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Exposed an accessor to surface the internal LiveObjects plugin interface.

- Refactor
  - Standardized a nosync_ naming convention across several plugin/API methods to enforce internal-queue usage without changing signatures.

- Documentation
  - Added a “Conventions” section requiring nosync_ methods be called on the client’s internal queue.
  - Updated API docs to state completion handlers and relevant methods run on the internal queue.

- Chores
  - Documentation and naming alignment for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->