### PR TITLE
Add API for fetching server time

### DIFF
--- a/Sources/_AblyPluginSupportPrivate/include/APPluginAPI.h
+++ b/Sources/_AblyPluginSupportPrivate/include/APPluginAPI.h
@@ -72,6 +72,14 @@ NS_SWIFT_SENDABLE
 /// Returns a realtime channel's current state.
 - (APRealtimeChannelState)nosync_stateForChannel:(id<APRealtimeChannel>)channel;
 
+/// Fetches the Ably server time from the REST API, per RTO16.
+///
+/// Per RTO16a, if the client knows the local clock's offset from the server time, then the server time will be calculated without making a request.
+///
+/// The completion handler will be called on the client's internal queue (see `-internalQueueForClient:`).
+- (void)nosync_fetchServerTimeForClient:(id<APRealtimeClient>)client
+                             completion:(void (^ _Nullable)(NSDate *_Nullable serverTime, _Nullable id<APPublicErrorInfo> error))completion;
+
 /// Logs a message to a logger.
 - (void)log:(NSString *)message
         withLevel:(APLogLevel)level


### PR DESCRIPTION
For the LiveObjects client to use when creating object IDs, per RTO16 (see https://github.com/ably/ably-liveobjects-swift-plugin/issues/50).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved server time synchronization capabilities for enhanced clock accuracy
  * Enhanced logging infrastructure with better diagnostic context information

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->