### PR TITLE
Add LiveObjects plugin API for receiving connection details

### DIFF
--- a/Sources/_AblyPluginSupportPrivate/include/APConnectionDetails.h
+++ b/Sources/_AblyPluginSupportPrivate/include/APConnectionDetails.h
@@ -1,0 +1,15 @@
+@import Foundation;
+
+NS_ASSUME_NONNULL_BEGIN
+
+NS_SWIFT_NAME(ConnectionDetailsProtocol)
+NS_SWIFT_SENDABLE
+/// The contents of a `CONNECTED` `ProtocolMessage`'s `connectionDetails`.
+@protocol APConnectionDetailsProtocol
+
+/// Wraps an `NSTimeInterval` containing the `objectsGCGracePeriod`, if any, in seconds.
+@property (nonatomic, readonly, nullable) NSNumber *objectsGCGracePeriod;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/_AblyPluginSupportPrivate/include/APLiveObjectsPlugin.h
+++ b/Sources/_AblyPluginSupportPrivate/include/APLiveObjectsPlugin.h
@@ -7,6 +7,7 @@
 @protocol APRealtimeChannel;
 @protocol APRealtimeClient;
 @protocol APPublicErrorInfo;
+@protocol APConnectionDetailsProtocol;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -82,6 +83,13 @@ NS_SWIFT_SENDABLE
 - (void)nosync_handleObjectSyncProtocolMessageWithObjectMessages:(NSArray<id<APObjectMessageProtocol>> *)objectMessages
                                     protocolMessageChannelSerial:(nullable NSString *)protocolMessageChannelSerial
                                                          channel:(id<APRealtimeChannel>)channel;
+
+/// Called whenever the client receives a `CONNECTED` `ProtocolMessage`, passing its `connectionDetails` (if any).
+///
+/// Parameters:
+/// - channel: The channel that should be informed about the connection details.
+- (void)nosync_onConnectedWithConnectionDetails:(nullable id<APConnectionDetailsProtocol>)connectionDetails
+                                        channel:(id<APRealtimeChannel>)channel;
 
 @end
 

--- a/Sources/_AblyPluginSupportPrivate/include/APPluginAPI.h
+++ b/Sources/_AblyPluginSupportPrivate/include/APPluginAPI.h
@@ -80,6 +80,9 @@ NS_SWIFT_SENDABLE
 - (void)nosync_fetchServerTimeForClient:(id<APRealtimeClient>)client
                              completion:(void (^ _Nullable)(NSDate *_Nullable serverTime, _Nullable id<APPublicErrorInfo> error))completion;
 
+/// The `connectionDetails` from the latest `CONNECTED` `ProtocolMessage` that the client received (`nil` if it did not contain a `connectionDetails`).
+- (nullable id<APConnectionDetailsProtocol>)nosync_latestConnectionDetailsForClient:(id<APRealtimeClient>)client;
+
 /// Logs a message to a logger.
 - (void)log:(NSString *)message
         withLevel:(APLogLevel)level


### PR DESCRIPTION
**Note: This PR is based on top of #4; please review that one first.**

So that the plugin can use the GC grace period when releasing tombstoned objects, per RTO10b (see https://github.com/ably/ably-liveobjects-swift-plugin/issues/32).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added enhanced connection details support to the Live Objects plugin infrastructure with garbage collection grace period tracking capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->