### PR TITLE
[AIT-324] Add supporting API needed for apply-on-ACK

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,60 @@ Further documentation will be added in the future.
 ## Conventions
 
 - Methods whose names begin with `nosync_` must always be called on the client's internal queue.
+
+## Dependency setup
+
+The intention is that:
+
+- ably-cocoa's `Package.swift` declares a dependency on ably-cocoa-plugin-support
+- each plugin's `Package.swift` declares a dependency on ably-cocoa-plugin-support
+- each plugin's `Package.swift` also declares a direct dependency on ably-cocoa
+
+This means that:
+
+- a given version of the plugin is able to specify a _minimum_ version of ably-cocoa
+- a given version of ably-cocoa is expected to work with all plugin versions whose minimum it satisfies — i.e. ably-cocoa is _not_ able to specify a minimum version of a plugin
+
+The only way that ably-cocoa can exclude certain plugin versions is by creating a clash in the major version of the ably-cocoa-plugin-support dependency; we avoid using this mechanism where possible as it can cause confusing dependency resolution error messages for users and complicates the release process.
+
+## Playbook for making changes
+
+This section describes how to make some common changes that require changes to all three repositories (ably-cocoa, the plugin, and this repo).
+
+### Adding new capabilities
+
+In this section we describe how to make _non-breaking plugin-support changes_ (i.e. a minor plugin-support version bump) that either introduce functionality only available in a new version of ably-cocoa, or introduce functionality only available in a new version of the plugin.
+
+The key point is that both of the following are breaking plugin-support changes and thus must be avoided:
+
+- adding a new required method to an Objective-C protocol (breaks implementers of that protocol)
+- removing a required method from an Objective-C protocol (breaks consumers of that protocol)
+
+#### Introducing new functionality only available in a new version of ably-cocoa
+
+1. Add a new `@optional` method or property.
+2. Increase the plugin's minimum ably-cocoa version so that this method is guaranteed to be implemented, and perform a runtime precondition failure if it is not.
+
+> [!NOTE]
+> Avoid introducing new `@optional` properties with a nullable type, since in this case Swift does not provide a mechanism for differentiating between "property not implemented" and "property implemented and its value is `nil`". Use a getter method in this situation instead.
+
+#### Introducing new functionality only available in a new version of the plugin
+
+1. Add a new `@optional` method or property.
+2. Perform a `-respondsToSelector:` check in ably-cocoa to decide whether this new API can be called. ably-cocoa **must** still behave correctly in the case where it cannot (i.e. where an old version of the plugin is being used).
+
+### Removing capabilities
+
+In this section we describe how to make _non-breaking plugin-support changes_ (i.e. a minor plugin-support version bump) that either remove functionality from ably-cocoa, or remove functionality from the plugin.
+
+This also covers the case where, in combination with [adding a new capability](#adding-new-capabilities), we are replacing a method with a new variant.
+
+The key point is that it is a breaking plugin-support change to remove a method from an Objective-C protocol (breaks consumers of that protocol) and this must thus be avoided.
+
+#### Removing functionality from the plugin
+
+Since the plugin can exclude older versions of ably-cocoa, the plugin is able to choose to throw a runtime exception in methods that it no longer wishes to implement. This should be combined with increasing the plugin's minimum ably-cocoa version to one that no longer calls the method, so that the exception is never triggered in practice.
+
+#### Removing functionality from ably-cocoa
+
+Since new versions of ably-cocoa can be used with old versions of the plugin, ably-cocoa must continue to provide functioning implementations of all methods.

--- a/Sources/_AblyPluginSupportPrivate/include/APConnectionDetails.h
+++ b/Sources/_AblyPluginSupportPrivate/include/APConnectionDetails.h
@@ -10,6 +10,13 @@ NS_SWIFT_SENDABLE
 /// Wraps an `NSTimeInterval` containing the `objectsGCGracePeriod`, if any, in seconds.
 @property (nonatomic, readonly, nullable) NSNumber *objectsGCGracePeriod;
 
+@optional
+
+/// The site code of the server that the client is connected to (CD2j).
+///
+/// May be absent if the server does not provide it.
+- (nullable NSString *)siteCode;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/_AblyPluginSupportPrivate/include/APLiveObjectsPlugin.h
+++ b/Sources/_AblyPluginSupportPrivate/include/APLiveObjectsPlugin.h
@@ -1,5 +1,6 @@
 #import <Foundation/Foundation.h>
 #import "APEncodingFormat.h"
+#import "APRealtimeChannelState.h"
 
 @protocol APLiveObjectsInternalPluginProtocol;
 @protocol APObjectMessageProtocol;
@@ -90,6 +91,19 @@ NS_SWIFT_SENDABLE
 /// - channel: The channel that should be informed about the connection details.
 - (void)nosync_onConnectedWithConnectionDetails:(nullable id<APConnectionDetailsProtocol>)connectionDetails
                                         channel:(id<APRealtimeChannel>)channel;
+
+@optional
+
+/// Called when the channel undergoes a state transition.
+///
+/// Parameters:
+/// - channel: The channel whose state changed.
+/// - state: The new channel state.
+/// - reason: The error reason associated with the state change, if any. Corresponds to `ARTRealtimeChannel.errorReason`.
+- (void)nosync_onChannelStateChanged:(id<APRealtimeChannel>)channel
+                             toState:(APRealtimeChannelState)state
+                              reason:(nullable id<APPublicErrorInfo>)reason
+  NS_SWIFT_NAME(nosync_onChannelStateChanged(_:toState:reason:));
 
 @end
 

--- a/Sources/_AblyPluginSupportPrivate/include/APPluginAPI.h
+++ b/Sources/_AblyPluginSupportPrivate/include/APPluginAPI.h
@@ -11,6 +11,7 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol APPublicClientOptions;
 @protocol APPublicRealtimeChannel;
 @protocol APPublicErrorInfo;
+@protocol APPublishResultProtocol;
 
 /// `APPluginAPIProtocol` provides a stable API for Ably-authored plugins to access certain private functionality of ably-cocoa.
 NS_SWIFT_NAME(PluginAPIProtocol)
@@ -79,6 +80,15 @@ NS_SWIFT_SENDABLE
 - (void)nosync_sendObjectWithObjectMessages:(NSArray<id<APObjectMessageProtocol>> *)objectMessages
                                     channel:(id<APRealtimeChannel>)channel
                                  completion:(void (^ _Nullable)(_Nullable id<APPublicErrorInfo> error))completion;
+
+@optional
+
+/// Same as `-nosync_sendObjectWithObjectMessages:channel:completion:`, but the completion handler additionally receives an `APPublishResultProtocol` containing the serials assigned to the published messages by the server.
+- (void)nosync_sendObjectWithObjectMessages:(NSArray<id<APObjectMessageProtocol>> *)objectMessages
+                                    channel:(id<APRealtimeChannel>)channel
+                       completionWithResult:(void (^ _Nullable)(_Nullable id<APPublishResultProtocol> publishResult, _Nullable id<APPublicErrorInfo> error))completion;
+
+@required
 
 /// Returns a realtime channel's current state.
 - (APRealtimeChannelState)nosync_stateForChannel:(id<APRealtimeChannel>)channel;

--- a/Sources/_AblyPluginSupportPrivate/include/APPublishResult.h
+++ b/Sources/_AblyPluginSupportPrivate/include/APPublishResult.h
@@ -1,0 +1,25 @@
+@import Foundation;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// The serial for a single published message.
+NS_SWIFT_SENDABLE
+NS_SWIFT_NAME(PublishResultSerialProtocol)
+@protocol APPublishResultSerialProtocol <NSObject>
+
+/// The message serial of the published message, or `nil` if the message was discarded due to a configured conflation rule.
+@property (nullable, nonatomic, readonly) NSString *value;
+
+@end
+
+/// Contains the result of a publish operation.
+NS_SWIFT_SENDABLE
+NS_SWIFT_NAME(PublishResultProtocol)
+@protocol APPublishResultProtocol <NSObject>
+
+/// An array of serials corresponding 1:1 to the messages that were published.
+@property (nonatomic, readonly) NSArray<id<APPublishResultSerialProtocol>> *serials;
+
+@end
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
Add methods for plugin to:

- get `PublishResult` when performing a publish
- learn about channel state changes
- learn about the `siteCode` of the server it's connected to

Related PRs:

- https://github.com/ably/ably-cocoa/pull/2193
- https://github.com/ably/ably-liveobjects-swift-plugin/pull/118

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added dependency setup and a playbook for managing cross-repo changes, plus version/compatibility guidance.

* **New Features**
  * Plugin support for channel state change notifications.
  * Publish-result tracking with per-message serials and completion support returning publish results.
  * Connection info may include an optional server site code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->