### PR TITLE
Remove backwards-compatibility scaffolding from apply-on-ACK APIs

### DIFF
--- a/Sources/_AblyPluginSupportPrivate/include/APConnectionDetails.h
+++ b/Sources/_AblyPluginSupportPrivate/include/APConnectionDetails.h
@@ -10,12 +10,10 @@ NS_SWIFT_SENDABLE
 /// Wraps an `NSTimeInterval` containing the `objectsGCGracePeriod`, if any, in seconds.
 @property (nonatomic, readonly, nullable) NSNumber *objectsGCGracePeriod;
 
-@optional
-
 /// The site code of the server that the client is connected to (CD2j).
 ///
 /// May be absent if the server does not provide it.
-- (nullable NSString *)siteCode;
+@property (nonatomic, readonly, nullable) NSString *siteCode;
 
 @end
 

--- a/Sources/_AblyPluginSupportPrivate/include/APLiveObjectsPlugin.h
+++ b/Sources/_AblyPluginSupportPrivate/include/APLiveObjectsPlugin.h
@@ -104,8 +104,6 @@ NS_SWIFT_SENDABLE
 - (void)nosync_onConnectedWithConnectionDetails:(nullable id<APConnectionDetailsProtocol>)connectionDetails
                                         channel:(id<APRealtimeChannel>)channel;
 
-@optional
-
 /// Called when the channel undergoes a state transition.
 ///
 /// Parameters:

--- a/Sources/_AblyPluginSupportPrivate/include/APPluginAPI.h
+++ b/Sources/_AblyPluginSupportPrivate/include/APPluginAPI.h
@@ -82,7 +82,7 @@ NS_SWIFT_SENDABLE
 /// - If the channel's state is neither SUSPENDED nor FAILED then the message will be submitted to the connection for further checks per RTL6c1 and RTL6c2. Note that these checks may cause the connection to immediately reject the message per RTL6c4.
 /// - If the channel's state is SUSPENDED or FAILED then the callback will be called immediately with an error per RTL6c4.
 ///
-/// If the message ends up being sent on the transport then the completion handler will be called to indicate the result of waiting for an `ACK` or `NACK`, or when the connection gives up on trying to send the message.
+/// If the message ends up being sent on the transport then the completion handler will be called to indicate the result of waiting for an `ACK` or `NACK`, or when the connection gives up on trying to send the message. The completion handler receives an `APPublishResultProtocol` containing the serials assigned to the published messages by the server.
 ///
 /// The completion handler will be called on the client's internal queue (see `-internalQueueForClient:`).
 ///
@@ -91,16 +91,7 @@ NS_SWIFT_SENDABLE
 /// - Note: This method does not currently implement the RTO15d message size checks; this will come in https://github.com/ably/ably-liveobjects-swift-plugin/issues/13.
 - (void)nosync_sendObjectWithObjectMessages:(NSArray<id<APObjectMessageProtocol>> *)objectMessages
                                     channel:(id<APRealtimeChannel>)channel
-                                 completion:(void (^ _Nullable)(_Nullable id<APPublicErrorInfo> error))completion;
-
-@optional
-
-/// Same as `-nosync_sendObjectWithObjectMessages:channel:completion:`, but the completion handler additionally receives an `APPublishResultProtocol` containing the serials assigned to the published messages by the server.
-- (void)nosync_sendObjectWithObjectMessages:(NSArray<id<APObjectMessageProtocol>> *)objectMessages
-                                    channel:(id<APRealtimeChannel>)channel
-                       completionWithResult:(void (^ _Nullable)(_Nullable id<APPublishResultProtocol> publishResult, _Nullable id<APPublicErrorInfo> error))completion;
-
-@required
+                                 completion:(void (^ _Nullable)(_Nullable id<APPublishResultProtocol> publishResult, _Nullable id<APPublicErrorInfo> error))completion;
 
 /// Returns a realtime channel's current state.
 - (APRealtimeChannelState)nosync_stateForChannel:(id<APRealtimeChannel>)channel;


### PR DESCRIPTION
Since we're doing a v2 release of plugin-support, the @optional
workarounds introduced in 8bfbbaa are no longer needed. Make all methods
required, convert the siteCode getter method back to a property, and
fold the completionWithResult: variant back into the original
completion: method.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Plugin protocol methods for channel state notifications updated to required status for all implementations
  * Message publishing API completion handler structure enhanced to include publish result information alongside error details
  * Consolidated publishing interface by removing duplicate method variants, streamlining the developer experience

<!-- end of auto-generated comment: release notes by coderabbit.ai -->